### PR TITLE
ci: release workflow and packaging (chg-0009)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Sync
+        run: |
+          uv lock
+          uv sync --dev
+
+      - name: Build package (wheel + sdist)
+        run: |
+          uv build
+          ls -l dist
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.whl
+            dist/*.tar.gz


### PR DESCRIPTION
Adds release workflow (tag push builds and attaches artifacts) and verifies uv build.